### PR TITLE
the MainWindow is staying at the same height, so only part of the AT …

### DIFF
--- a/active-directory-wpf-msgraph-v2/MainWindow.xaml
+++ b/active-directory-wpf-msgraph-v2/MainWindow.xaml
@@ -5,7 +5,7 @@
         xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
         xmlns:local="clr-namespace:active_directory_wpf_msgraph_v2"
         mc:Ignorable="d"
-        Title="MainWindow" Height="350" Width="525">
+        Title="MainWindow" Height="Auto" Width="525" SizeToContent="Height">
     <Grid>
         <StackPanel Background="Azure">
             <StackPanel Orientation="Horizontal" HorizontalAlignment="Right">


### PR DESCRIPTION
…is shown. User would need to select the window and expand the height to see the entire AT. Made the height property size to the content, so the entire AT is shown in the window.