### PR TITLE
Standardize code replacement strings - Windows desktop quickstart

### DIFF
--- a/active-directory-wpf-msgraph-v2/App.xaml.cs
+++ b/active-directory-wpf-msgraph-v2/App.xaml.cs
@@ -24,11 +24,11 @@ namespace active_directory_wpf_msgraph_v2
         //   - for any Work or School accounts, use organizations
         //   - for any Work or School accounts, or Microsoft personal account, use common
         //   - for Microsoft Personal account, use consumers
-        private static string ClientId = "0b8b0665-bc13-4fdc-bd72-e0227b9fc011";
+        private static string ClientId = "Enter_the_Application_Id_here";
 
         // Note: Tenant is important for the quickstart. We'd need to check with Andre/Portal if we
         // want to change to the AadAuthorityAudience.
-        private static string Tenant = "common";
+        private static string Tenant = "Enter_the_Tenant_Info_Here";
 
         private static IPublicClientApplication _clientApp ;
 


### PR DESCRIPTION
We have a working prototype to improve developer experience in quickstarts so that the downloaded code sample is ready-to-run and no longer needs manual step of copy-pasting the code blob with clientId/password/etc info. For that, we're standardizing code replacement strings as follows:
ClientIdStringToReplace : "Enter_the_Application_Id_here"
ClientTenantToReplace : "Enter_the_Tenant_Info_Here"
ClientSecretToReplace": "Enter_the_Client_Secret_Here"
BundleIdToReplace : "Enter_the_Bundle_Id_Here"
RedirectUriToReplace : "Enter_the_Redirect_URI_Here"
PackageNameToReplace : "Enter_the_Package_Name_Here"
SignatureHashToReplace : "Enter_the_Signature_Hash_Here"