### PR TITLE
Adding pro tip for gov cloud

### DIFF
--- a/active-directory-wpf-msgraph-v2/App.xaml.cs
+++ b/active-directory-wpf-msgraph-v2/App.xaml.cs
@@ -6,6 +6,8 @@ namespace active_directory_wpf_msgraph_v2
     /// <summary>
     /// Interaction logic for App.xaml
     /// </summary>
+    
+    // To change from Microsoft public cloud to a national cloud, use another value of AzureCloudInstance
     public partial class App : Application
     {
         static App()


### PR DESCRIPTION
Gov cloud needs another instance of AzureCloudInstance.