### PR TITLE
Adding replace tokens for national cloud scenarios

### DIFF
--- a/AppCreationScripts/apps.json
+++ b/AppCreationScripts/apps.json
@@ -33,7 +33,8 @@
           "settingFile": "/active-directory-wpf-msgraph-v2/App.xaml.cs",
           "replaceTokens": {
             "appId": "4a1aa1d5-c567-49d0-ad0b-cd957a47f842",
-            "tenantId": "common"
+            "tenantId": "common",
+            "authorityEndpointHost": "https://login.microsoftonline.com/"
           }
         },
         {

--- a/AppCreationScripts/apps.json
+++ b/AppCreationScripts/apps.json
@@ -28,15 +28,19 @@
           ]
         }
       ],
-      "codeConfigurations": [	
+      "codeConfigurations": [
         {
-		      "settingFile": "/active-directory-wpf-msgraph-v2/App.xaml.cs", 
-		      "replaceTokens": 
-            {
-              "appId": "4a1aa1d5-c567-49d0-ad0b-cd957a47f842",
-              "tenantId": "common"
-			      }
-         }
+          "settingFile": "/active-directory-wpf-msgraph-v2/App.xaml.cs",
+          "replaceTokens": {
+            "appId": "4a1aa1d5-c567-49d0-ad0b-cd957a47f842",
+            "tenantId": "common"
+          }
+        },
+        {
+          "settingFile": "/active-directory-wpf-msgraph-v2/MainWindow.xaml.cs",
+          "replaceTokens": {
+            "msgraphEndpointHost": "https://graph.microsoft.com"
+        }
        ]		
     }
   ]

--- a/AppCreationScripts/apps.json
+++ b/AppCreationScripts/apps.json
@@ -40,7 +40,7 @@
         {
           "settingFile": "/active-directory-wpf-msgraph-v2/MainWindow.xaml.cs",
           "replaceTokens": {
-            "msgraphEndpointHost": "https://graph.microsoft.com"
+            "msgraphEndpointHost": "https://graph.microsoft.com/"
         }
        ]		
     }

--- a/active-directory-wpf-msgraph-v2/App.xaml.cs
+++ b/active-directory-wpf-msgraph-v2/App.xaml.cs
@@ -10,6 +10,7 @@ namespace active_directory_wpf_msgraph_v2
     // To change from Microsoft public cloud to a national cloud, use another value of AzureCloudInstance
     public partial class App : Application
     {
+        // Are we the only ones who use AzureCloudInstance?
         static App()
         {
             _clientApp = PublicClientApplicationBuilder.Create(ClientId)

--- a/active-directory-wpf-msgraph-v2/App.xaml.cs
+++ b/active-directory-wpf-msgraph-v2/App.xaml.cs
@@ -10,11 +10,10 @@ namespace active_directory_wpf_msgraph_v2
     // To change from Microsoft public cloud to a national cloud, use another value of AzureCloudInstance
     public partial class App : Application
     {
-        // Are we the only ones who use AzureCloudInstance?
         static App()
         {
             _clientApp = PublicClientApplicationBuilder.Create(ClientId)
-                .WithAuthority(AzureCloudInstance.AzurePublic, Tenant)
+                .WithAuthority($"{Instance}{Tenant}")
                 .WithDefaultRedirectUri()
                 .Build();
             TokenCacheHelper.EnableSerialization(_clientApp.UserTokenCache);
@@ -33,7 +32,7 @@ namespace active_directory_wpf_msgraph_v2
         // Note: Tenant is important for the quickstart. We'd need to check with Andre/Portal if we
         // want to change to the AadAuthorityAudience.
         private static string Tenant = "common";
-
+        private static string Instance = "https://login.microsoftonline.com/";
         private static IPublicClientApplication _clientApp ;
 
         public static IPublicClientApplication PublicClientApp { get { return _clientApp; } }

--- a/active-directory-wpf-msgraph-v2/MainWindow.xaml.cs
+++ b/active-directory-wpf-msgraph-v2/MainWindow.xaml.cs
@@ -10,13 +10,13 @@ namespace active_directory_wpf_msgraph_v2
     /// <summary>
     /// Interaction logic for MainWindow.xaml
     /// </summary>
+ 
     public partial class MainWindow : Window
     {
         //Set the API Endpoint to Graph 'me' endpoint. 
         // To change from Microsoft public cloud to a national cloud, use another value of graphAPIEndpoint.
         // Reference with Graph endpoints here: https://docs.microsoft.com/graph/deployments#microsoft-graph-and-graph-explorer-service-root-endpoints
-        static string graphAPIEndpoint = "https://graph.microsoft.com";
-        string graphAPIEndpointMe = graphAPIEndpoint + "/v1.0/me";
+        string graphAPIEndpoint = "https://graph.microsoft.com/v1.0/me";
 
         //Set the scope for API call to user.read
         string[] scopes = new string[] { "user.read" };
@@ -72,7 +72,7 @@ namespace active_directory_wpf_msgraph_v2
 
             if (authResult != null)
             {
-                ResultText.Text = await GetHttpContentWithToken(graphAPIEndpointMe, authResult.AccessToken);
+                ResultText.Text = await GetHttpContentWithToken(graphAPIEndpoint, authResult.AccessToken);
                 DisplayBasicTokenInfo(authResult);
                 this.SignOutButton.Visibility = Visibility.Visible;
             }

--- a/active-directory-wpf-msgraph-v2/MainWindow.xaml.cs
+++ b/active-directory-wpf-msgraph-v2/MainWindow.xaml.cs
@@ -15,7 +15,8 @@ namespace active_directory_wpf_msgraph_v2
         //Set the API Endpoint to Graph 'me' endpoint. 
         // To change from Microsoft public cloud to a national cloud, use another value of graphAPIEndpoint.
         // Reference with Graph endpoints here: https://docs.microsoft.com/graph/deployments#microsoft-graph-and-graph-explorer-service-root-endpoints
-        string graphAPIEndpoint = "https://graph.microsoft.com/v1.0/me";
+        static string graphAPIEndpoint = "https://graph.microsoft.com";
+        string graphAPIEndpointMe = graphAPIEndpoint + "/v1.0/me";
 
         //Set the scope for API call to user.read
         string[] scopes = new string[] { "user.read" };
@@ -71,7 +72,7 @@ namespace active_directory_wpf_msgraph_v2
 
             if (authResult != null)
             {
-                ResultText.Text = await GetHttpContentWithToken(graphAPIEndpoint, authResult.AccessToken);
+                ResultText.Text = await GetHttpContentWithToken(graphAPIEndpointMe, authResult.AccessToken);
                 DisplayBasicTokenInfo(authResult);
                 this.SignOutButton.Visibility = Visibility.Visible;
             }


### PR DESCRIPTION
Are we the only ones that use AzureCloudInstance? See changes in app.xaml.cs.