### PR TITLE
Standardize the way how the authentication token is acquired.

### DIFF
--- a/active-directory-wpf-msgraph-v2/MainWindow.xaml.cs
+++ b/active-directory-wpf-msgraph-v2/MainWindow.xaml.cs
@@ -54,7 +54,7 @@ namespace active_directory_wpf_msgraph_v2
                 try
                 {
                     authResult = await app.AcquireTokenInteractive(scopes)
-                        .WithAccount(accounts.FirstOrDefault())
+                        .WithAccount(firstAccount)
                         .WithParentActivityOrWindow(new WindowInteropHelper(this).Handle) // optional, used to center the browser on the window
                         .WithPrompt(Prompt.SelectAccount)
                         .ExecuteAsync();


### PR DESCRIPTION
In the code example there is a method call to AcquireTokenSilent which takes the firstAccount variable as the Account parameter.
For the AcquireTokenInteractive call I changed the Methodcall to work with the same parameters. 