### PR TITLE
Demonstrate usage of WAM (and update to MSAL 4.23)

### DIFF
--- a/active-directory-wpf-msgraph-v2/App.config
+++ b/active-directory-wpf-msgraph-v2/App.config
@@ -1,6 +1,6 @@
-﻿<?xml version="1.0" encoding="utf-8" ?>
+<?xml version="1.0" encoding="utf-8"?>
 <configuration>
     <startup> 
-        <supportedRuntime version="v4.0" sku=".NETFramework,Version=v4.5.2" />
+        <supportedRuntime version="v4.0" sku=".NETFramework,Version=v4.6.1"/>
     </startup>
 </configuration>

--- a/active-directory-wpf-msgraph-v2/App.xaml.cs
+++ b/active-directory-wpf-msgraph-v2/App.xaml.cs
@@ -13,7 +13,7 @@ namespace active_directory_wpf_msgraph_v2
     {
         static App()
         {
-            CreateApplication(false);
+            CreateApplication(true);
         }
 
         public static void CreateApplication(bool useWam)

--- a/active-directory-wpf-msgraph-v2/App.xaml.cs
+++ b/active-directory-wpf-msgraph-v2/App.xaml.cs
@@ -1,4 +1,5 @@
 ﻿using Microsoft.Identity.Client;
+using System.Linq.Expressions;
 using System.Windows;
 
 namespace active_directory_wpf_msgraph_v2
@@ -6,16 +7,27 @@ namespace active_directory_wpf_msgraph_v2
     /// <summary>
     /// Interaction logic for App.xaml
     /// </summary>
-    
+
     // To change from Microsoft public cloud to a national cloud, use another value of AzureCloudInstance
     public partial class App : Application
     {
         static App()
         {
-            _clientApp = PublicClientApplicationBuilder.Create(ClientId)
+            CreateApplication(false);
+        }
+
+        public static void CreateApplication(bool useWam)
+        {
+            var builder = PublicClientApplicationBuilder.Create(ClientId)
                 .WithAuthority($"{Instance}{Tenant}")
-                .WithDefaultRedirectUri()
-                .Build();
+                .WithDefaultRedirectUri();
+
+            if (useWam)
+            {
+                builder.WithExperimentalFeatures();
+                builder.WithBroker(true);  // Requires redirect URI "ms-appx-web://microsoft.aad.brokerplugin/{client_id}" in app registration
+            }
+            _clientApp = builder.Build();
             TokenCacheHelper.EnableSerialization(_clientApp.UserTokenCache);
         }
 
@@ -33,7 +45,7 @@ namespace active_directory_wpf_msgraph_v2
         // want to change to the AadAuthorityAudience.
         private static string Tenant = "common";
         private static string Instance = "https://login.microsoftonline.com/";
-        private static IPublicClientApplication _clientApp ;
+        private static IPublicClientApplication _clientApp;
 
         public static IPublicClientApplication PublicClientApp { get { return _clientApp; } }
     }

--- a/active-directory-wpf-msgraph-v2/MainWindow.xaml
+++ b/active-directory-wpf-msgraph-v2/MainWindow.xaml
@@ -5,10 +5,15 @@
         xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
         xmlns:local="clr-namespace:active_directory_wpf_msgraph_v2"
         mc:Ignorable="d"
-        Title="MainWindow" Height="Auto" Width="525" SizeToContent="Height">
+        Title="MainWindow" Height="Auto" Width="600" SizeToContent="Height">
     <Grid>
         <StackPanel Background="Azure">
             <StackPanel Orientation="Horizontal" HorizontalAlignment="Right">
+                <ComboBox x:Name="howToSignIn" SelectedIndex="0" SelectionChanged="UseWam_Changed" VerticalAlignment="Center">
+                    <ComboBoxItem Tag="0">Use account used to signed-in in Windows (WAM)</ComboBoxItem>
+                    <ComboBoxItem Tag="1">Use one of the Accounts known by Windows (WAM)</ComboBoxItem>
+                    <ComboBoxItem Tag="1">Use any account (Azure AD)</ComboBoxItem>
+                </ComboBox>
                 <Button x:Name="CallGraphButton" Content="Call Microsoft Graph API" HorizontalAlignment="Right" Padding="5" Click="CallGraphButton_Click" Margin="5" FontFamily="Segoe Ui"/>
                 <Button x:Name="SignOutButton" Content="Sign-Out" HorizontalAlignment="Right" Padding="5" Click="SignOutButton_Click" Margin="5" Visibility="Collapsed" FontFamily="Segoe Ui"/>
             </StackPanel>

--- a/active-directory-wpf-msgraph-v2/MainWindow.xaml
+++ b/active-directory-wpf-msgraph-v2/MainWindow.xaml
@@ -10,9 +10,9 @@
         <StackPanel Background="Azure">
             <StackPanel Orientation="Horizontal" HorizontalAlignment="Right">
                 <ComboBox x:Name="howToSignIn" SelectedIndex="0" SelectionChanged="UseWam_Changed" VerticalAlignment="Center">
-                    <ComboBoxItem Tag="0">Use account used to signed-in in Windows (WAM)</ComboBoxItem>
-                    <ComboBoxItem Tag="1">Use one of the Accounts known by Windows (WAM)</ComboBoxItem>
-                    <ComboBoxItem Tag="1">Use any account (Azure AD)</ComboBoxItem>
+                    <ComboBoxItem>Use account used to signed-in in Windows (WAM)</ComboBoxItem>
+                    <ComboBoxItem>Use one of the Accounts known by Windows (WAM)</ComboBoxItem>
+                    <ComboBoxItem>Use any account (Azure AD)</ComboBoxItem>
                 </ComboBox>
                 <Button x:Name="CallGraphButton" Content="Call Microsoft Graph API" HorizontalAlignment="Right" Padding="5" Click="CallGraphButton_Click" Margin="5" FontFamily="Segoe Ui"/>
                 <Button x:Name="SignOutButton" Content="Sign-Out" HorizontalAlignment="Right" Padding="5" Click="SignOutButton_Click" Margin="5" Visibility="Collapsed" FontFamily="Segoe Ui"/>

--- a/active-directory-wpf-msgraph-v2/MainWindow.xaml.cs
+++ b/active-directory-wpf-msgraph-v2/MainWindow.xaml.cs
@@ -27,11 +27,6 @@ namespace active_directory_wpf_msgraph_v2
             InitializeComponent();
         }
 
-        private void UseWam_Changed(object sender, RoutedEventArgs e)
-        {
-            App.CreateApplication(howToSignIn.SelectedIndex != 2); // Not Azure AD accounts (that is use WAM accounts)
-        }
-
         /// <summary>
         /// Call AcquireToken - to acquire a token requiring user to sign-in
         /// </summary>
@@ -47,7 +42,13 @@ namespace active_directory_wpf_msgraph_v2
             // WAM will always get an account in the cache. So if we want
             // to have a chance to select the accounts interactively, we need to
             // force the non-account
-            if (howToSignIn.SelectedIndex == 1) // Account signed-in with Windows
+            if (howToSignIn.SelectedIndex == 0) // Account signed-in with Windows
+            {
+                firstAccount = PublicClientApplication.OperatingSystemAccount;
+            }
+
+            // WAM
+            else if (howToSignIn.SelectedIndex == 1)
             {
                 firstAccount = null;
             }
@@ -154,6 +155,10 @@ namespace active_directory_wpf_msgraph_v2
             }
         }
 
-
+        private void UseWam_Changed(object sender, System.Windows.Controls.SelectionChangedEventArgs e)
+        {
+            SignOutButton_Click(sender, e);
+            App.CreateApplication(howToSignIn.SelectedIndex != 2); // Not Azure AD accounts (that is use WAM accounts)
+        }
     }
 }

--- a/active-directory-wpf-msgraph-v2/MainWindow.xaml.cs
+++ b/active-directory-wpf-msgraph-v2/MainWindow.xaml.cs
@@ -27,6 +27,11 @@ namespace active_directory_wpf_msgraph_v2
             InitializeComponent();
         }
 
+        private void UseWam_Changed(object sender, RoutedEventArgs e)
+        {
+            App.CreateApplication(howToSignIn.SelectedIndex != 2);
+        }
+
         /// <summary>
         /// Call AcquireToken - to acquire a token requiring user to sign-in
         /// </summary>
@@ -37,9 +42,20 @@ namespace active_directory_wpf_msgraph_v2
             ResultText.Text = string.Empty;
             TokenInfoText.Text = string.Empty;
 
-            var accounts = await app.GetAccountsAsync();
-            var firstAccount = accounts.FirstOrDefault();
+            IAccount firstAccount;
 
+            // WAM will always get an account in the cache. So if we want
+            // to have a chance to select the accounts interactively, we need to
+            // force the non-account
+            if (howToSignIn.SelectedIndex == 1)
+            {
+                firstAccount = null;
+            }
+            else
+            {
+                var accounts = await app.GetAccountsAsync();
+                firstAccount = accounts.FirstOrDefault();
+            }
             try
             {
                 authResult = await app.AcquireTokenSilent(scopes, firstAccount)
@@ -137,5 +153,7 @@ namespace active_directory_wpf_msgraph_v2
                 TokenInfoText.Text += $"Token Expires: {authResult.ExpiresOn.ToLocalTime()}" + Environment.NewLine;
             }
         }
+
+
     }
 }

--- a/active-directory-wpf-msgraph-v2/MainWindow.xaml.cs
+++ b/active-directory-wpf-msgraph-v2/MainWindow.xaml.cs
@@ -39,24 +39,29 @@ namespace active_directory_wpf_msgraph_v2
 
             IAccount firstAccount;
 
-            // WAM will always get an account in the cache. So if we want
-            // to have a chance to select the accounts interactively, we need to
-            // force the non-account
-            if (howToSignIn.SelectedIndex == 0) // Account signed-in with Windows
+            switch(howToSignIn.SelectedIndex)
             {
-                firstAccount = PublicClientApplication.OperatingSystemAccount;
+                // 0: Use account used to signed-in in Windows (WAM)
+                case 0:
+                    // WAM will always get an account in the cache. So if we want
+                    // to have a chance to select the accounts interactively, we need to
+                    // force the non-account
+                    firstAccount = PublicClientApplication.OperatingSystemAccount;
+                    break;
+
+                //  1: Use one of the Accounts known by Windows(WAM)
+                case 1:
+                    // We force WAM to display the dialog with the accounts
+                    firstAccount = null;
+                    break;
+
+                //  Use any account(Azure AD). It's not using WAM
+                default:
+                    var accounts = await app.GetAccountsAsync();
+                    firstAccount = accounts.FirstOrDefault();
+                    break;
             }
 
-            // WAM
-            else if (howToSignIn.SelectedIndex == 1)
-            {
-                firstAccount = null;
-            }
-            else
-            {
-                var accounts = await app.GetAccountsAsync();
-                firstAccount = accounts.FirstOrDefault();
-            }
             try
             {
                 authResult = await app.AcquireTokenSilent(scopes, firstAccount)

--- a/active-directory-wpf-msgraph-v2/MainWindow.xaml.cs
+++ b/active-directory-wpf-msgraph-v2/MainWindow.xaml.cs
@@ -29,7 +29,7 @@ namespace active_directory_wpf_msgraph_v2
 
         private void UseWam_Changed(object sender, RoutedEventArgs e)
         {
-            App.CreateApplication(howToSignIn.SelectedIndex != 2);
+            App.CreateApplication(howToSignIn.SelectedIndex != 2); // Not Azure AD accounts (that is use WAM accounts)
         }
 
         /// <summary>
@@ -47,7 +47,7 @@ namespace active_directory_wpf_msgraph_v2
             // WAM will always get an account in the cache. So if we want
             // to have a chance to select the accounts interactively, we need to
             // force the non-account
-            if (howToSignIn.SelectedIndex == 1)
+            if (howToSignIn.SelectedIndex == 1) // Account signed-in with Windows
             {
                 firstAccount = null;
             }

--- a/active-directory-wpf-msgraph-v2/Properties/Resources.Designer.cs
+++ b/active-directory-wpf-msgraph-v2/Properties/Resources.Designer.cs
@@ -19,7 +19,7 @@ namespace active_directory_wpf_msgraph_v2.Properties {
     // class via a tool like ResGen or Visual Studio.
     // To add or remove a member, edit your .ResX file then rerun ResGen
     // with the /str option, or rebuild your VS project.
-    [global::System.CodeDom.Compiler.GeneratedCodeAttribute("System.Resources.Tools.StronglyTypedResourceBuilder", "4.0.0.0")]
+    [global::System.CodeDom.Compiler.GeneratedCodeAttribute("System.Resources.Tools.StronglyTypedResourceBuilder", "16.0.0.0")]
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute()]
     [global::System.Runtime.CompilerServices.CompilerGeneratedAttribute()]
     internal class Resources {

--- a/active-directory-wpf-msgraph-v2/Properties/Settings.Designer.cs
+++ b/active-directory-wpf-msgraph-v2/Properties/Settings.Designer.cs
@@ -12,7 +12,7 @@ namespace active_directory_wpf_msgraph_v2.Properties {
     
     
     [global::System.Runtime.CompilerServices.CompilerGeneratedAttribute()]
-    [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Microsoft.VisualStudio.Editors.SettingsDesigner.SettingsSingleFileGenerator", "15.1.0.0")]
+    [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Microsoft.VisualStudio.Editors.SettingsDesigner.SettingsSingleFileGenerator", "16.7.0.0")]
     internal sealed partial class Settings : global::System.Configuration.ApplicationSettingsBase {
         
         private static Settings defaultInstance = ((Settings)(global::System.Configuration.ApplicationSettingsBase.Synchronized(new Settings())));

--- a/active-directory-wpf-msgraph-v2/active-directory-wpf-msgraph-v2.csproj
+++ b/active-directory-wpf-msgraph-v2/active-directory-wpf-msgraph-v2.csproj
@@ -101,7 +101,7 @@
   </ItemGroup>
   <ItemGroup>
     <PackageReference Include="Microsoft.Identity.Client">
-      <Version>4.22.0</Version>
+      <Version>4.20.0</Version>
     </PackageReference>
   </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />

--- a/active-directory-wpf-msgraph-v2/active-directory-wpf-msgraph-v2.csproj
+++ b/active-directory-wpf-msgraph-v2/active-directory-wpf-msgraph-v2.csproj
@@ -8,11 +8,12 @@
     <OutputType>WinExe</OutputType>
     <RootNamespace>active_directory_wpf_msgraph_v2</RootNamespace>
     <AssemblyName>active_directory_wpf_msgraph_v2</AssemblyName>
-    <TargetFrameworkVersion>v4.5.2</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v4.6.1</TargetFrameworkVersion>
     <FileAlignment>512</FileAlignment>
     <ProjectTypeGuids>{60dc8134-eba5-43b8-bcc9-bb4bc16c2548};{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}</ProjectTypeGuids>
     <WarningLevel>4</WarningLevel>
     <AutoGenerateBindingRedirects>true</AutoGenerateBindingRedirects>
+    <TargetFrameworkProfile />
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
     <PlatformTarget>AnyCPU</PlatformTarget>
@@ -100,7 +101,7 @@
   </ItemGroup>
   <ItemGroup>
     <PackageReference Include="Microsoft.Identity.Client">
-      <Version>4.19.0</Version>
+      <Version>4.20.0</Version>
     </PackageReference>
   </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />

--- a/active-directory-wpf-msgraph-v2/active-directory-wpf-msgraph-v2.csproj
+++ b/active-directory-wpf-msgraph-v2/active-directory-wpf-msgraph-v2.csproj
@@ -101,7 +101,7 @@
   </ItemGroup>
   <ItemGroup>
     <PackageReference Include="Microsoft.Identity.Client">
-      <Version>4.20.0</Version>
+      <Version>4.22.0</Version>
     </PackageReference>
   </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />

--- a/active-directory-wpf-msgraph-v2/active-directory-wpf-msgraph-v2.csproj
+++ b/active-directory-wpf-msgraph-v2/active-directory-wpf-msgraph-v2.csproj
@@ -101,7 +101,7 @@
   </ItemGroup>
   <ItemGroup>
     <PackageReference Include="Microsoft.Identity.Client">
-      <Version>4.20.0</Version>
+      <Version>4.23.0</Version>
     </PackageReference>
   </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />


### PR DESCRIPTION
Update to MSAL.NET 4.20 and showcase the usage of WAM.
- Adds a combo box to use WAM (default account, any WAM account, any Azure AD Account)
- Updates the app creation depending on the combo box's selected option
- and update `CallGraphButton_Click` to enable any WAM account